### PR TITLE
lock chef version in kitchen yml, windows_package weirdness

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -2,6 +2,7 @@
 driver:
   name: vagrant
   provider: virtualbox
+  require_chef_omnibus: 12.5.1
 
 provisioner:
   name: chef_zero


### PR DESCRIPTION
- [ ] @laynes 

The `windows_package` resource is failing to DL the package using Chef 12.6.1 so I'm locking this down to 12.5.1 for now.